### PR TITLE
test: add initial pytest suite for ascii_wheel + improve coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Byte-compiled / cache files
+__pycache__/
+*.py[cod]
+*.class
+
+# pytest
+.pytest_cache/
+
+# virtualenv
+.venv/
+venv/
+ENV/
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/tests/test_ascii_wheel.py
+++ b/tests/test_ascii_wheel.py
@@ -1,0 +1,37 @@
+import os
+import sys
+
+# Make src/PlayGame importable
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'src', 'PlayGame'))
+
+import ascii_wheel
+
+
+def test_parse_values_arg_mappings():
+    raw = 'BK, LT, 500, 0, -1, LOSE, LOSETURN, LOSE_TURN, BANKRUPT, 250'
+    out = ascii_wheel.parse_values_arg(raw)
+    assert out == [-1, 0, 500, 0, -1, 0, 0, 0, -1, 250]
+
+
+def test_parse_values_arg_invalid_raises():
+    # Non-numeric and not a known token should raise ValueError
+    try:
+        ascii_wheel.parse_values_arg('X')
+        raised = False
+    except ValueError:
+        raised = True
+    assert raised
+
+
+def test_draw_ascii_wheel_outputs_labels(capsys):
+    # Small wheel and a few values. Ensure labels appear as expected.
+    values = [0, -1, 100, 200]
+    ascii_wheel.draw_ascii_wheel(values, radius=3, label_style='short')
+    out_short = capsys.readouterr().out
+    assert '0' in out_short
+    assert 'BK' in out_short
+
+    ascii_wheel.draw_ascii_wheel(values, radius=3, label_style='long')
+    out_long = capsys.readouterr().out
+    assert 'LOSE TURN' in out_long
+    assert 'BANKRUPT' in out_long


### PR DESCRIPTION
Summary
- Add pytest-based tests for src/PlayGame/ascii_wheel.py
- Cover parse_values_arg token handling and minimal rendering output

Changes
- tests/test_ascii_wheel.py: 3 unit tests
  - test_parse_values_arg_mappings
  - test_parse_values_arg_invalid_raises
  - test_draw_ascii_wheel_outputs_labels
- Add .gitignore to exclude caches and virtualenv artifacts

Motivation
This project had no automated tests. These tests introduce a foundation for test coverage and help prevent regressions in ascii_wheel’s parsing and label rendering logic.

How to run tests
- pip install pytest
- python -m pytest -q

Notes
- Tests import ascii_wheel by adding src/PlayGame to sys.path to keep changes minimal.
- No behavior changes to production code.


@KentonMurray can click here to [continue refining the PR](https://app.all-hands.dev/conversations/9cc5980e72ea44c1bb84e94abf9ff910)